### PR TITLE
[Feat/#9] font, color Theme 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,10 @@
-"use client";
 import SUIT from "@/shared/assets/font/font";
 import ReactQueryClientProvider from "@/shared/lib/reactQuery/ReactQueryClientProvider";
 import StyledComponentsRegistry from "@/shared/lib/styledComponents/StyledComponentsRegistry";
 import StyledReset from "@/shared/lib/styledComponents/StyledReset";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import "./global.css";
-import { ThemeProvider } from "styled-components";
-import { theme } from "../shared/lib/styledComponents/theme";
-
+import StyledComponentsTheme from "@/shared/lib/styledComponents/StyledComponentsTheme";
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -18,10 +15,10 @@ export default function RootLayout({
       <body>
         <ReactQueryClientProvider>
           <StyledComponentsRegistry>
-            <ThemeProvider theme={theme}>
+            <StyledComponentsTheme>
               <StyledReset />
               {children}
-            </ThemeProvider>
+            </StyledComponentsTheme>
           </StyledComponentsRegistry>
           <ReactQueryDevtools initialIsOpen={false} />
         </ReactQueryClientProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,12 @@
-import SUIT from '@/shared/assets/font/font';
-import ReactQueryClientProvider from '@/shared/lib/reactQuery/ReactQueryClientProvider';
-import StyledComponentsRegistry from '@/shared/lib/styledComponents/StyledComponentsRegistry';
-import StyledReset from '@/shared/lib/styledComponents/StyledReset';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import './global.css';
+"use client";
+import SUIT from "@/shared/assets/font/font";
+import ReactQueryClientProvider from "@/shared/lib/reactQuery/ReactQueryClientProvider";
+import StyledComponentsRegistry from "@/shared/lib/styledComponents/StyledComponentsRegistry";
+import StyledReset from "@/shared/lib/styledComponents/StyledReset";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import "./global.css";
+import { ThemeProvider } from "styled-components";
+import { theme } from "../shared/lib/styledComponents/theme";
 
 export default function RootLayout({
   children,
@@ -15,8 +18,10 @@ export default function RootLayout({
       <body>
         <ReactQueryClientProvider>
           <StyledComponentsRegistry>
-            <StyledReset />
-            {children}
+            <ThemeProvider theme={theme}>
+              <StyledReset />
+              {children}
+            </ThemeProvider>
           </StyledComponentsRegistry>
           <ReactQueryDevtools initialIsOpen={false} />
         </ReactQueryClientProvider>

--- a/src/shared/lib/styledComponents/StyledComponentsTheme.tsx
+++ b/src/shared/lib/styledComponents/StyledComponentsTheme.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ThemeProvider } from "styled-components";
+import { theme } from "./theme";
+
+import React, { ReactNode } from "react";
+
+const StyledComponentsTheme = ({ children }: { children: ReactNode }) => {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};
+
+export default StyledComponentsTheme;

--- a/src/shared/lib/styledComponents/styled.d.ts
+++ b/src/shared/lib/styledComponents/styled.d.ts
@@ -1,0 +1,8 @@
+import "styled-components";
+import { ColorsTypes, FontsTypes } from "./theme";
+declare module "styled-components" {
+  export interface DefaultTheme {
+    colors: ColorsTypes;
+    fonts: FontsTypes;
+  }
+}

--- a/src/shared/lib/styledComponents/theme.ts
+++ b/src/shared/lib/styledComponents/theme.ts
@@ -1,19 +1,20 @@
 import { css } from "styled-components";
+
 export const theme = {
   fonts: {
-    head3: css`
+    headline3: css`
       font-size: 28px;
       font-style: normal;
       font-weight: 700;
-      line-height: 32px;
+      line-height: 40px;
     `,
-    head2: css`
+    headline2: css`
       font-size: 24px;
       font-style: normal;
       font-weight: 700;
       line-height: 32px;
     `,
-    head1: css`
+    headline1: css`
       font-size: 20px;
       font-style: normal;
       font-weight: 700;
@@ -25,12 +26,14 @@ export const theme = {
       font-weight: 700;
       line-height: 26px;
     `,
+    // 다지안 확인 대기
     subHead3: css`
       font-size: 16px;
       font-style: normal;
       font-weight: 700;
-      line-height: 22px;
+      line-height: 24px;
     `,
+    // 다지안 확인 대기
     subHead2: css`
       font-size: 15px;
       font-style: normal;

--- a/src/shared/lib/styledComponents/theme.ts
+++ b/src/shared/lib/styledComponents/theme.ts
@@ -1,0 +1,100 @@
+import { css } from "styled-components";
+export const theme = {
+  fonts: {
+    head3: css`
+      font-size: 28px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 32px;
+    `,
+    head2: css`
+      font-size: 24px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 32px;
+    `,
+    head1: css`
+      font-size: 20px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 28px;
+    `,
+    subHead4: css`
+      font-size: 18px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 26px;
+    `,
+    subHead3: css`
+      font-size: 16px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 22px;
+    `,
+    subHead2: css`
+      font-size: 15px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 23px;
+    `,
+    subHead1: css`
+      font-size: 14px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 22px;
+    `,
+    body4: css`
+      font-size: 18px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 26px;
+    `,
+    body3: css`
+      font-size: 16px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 24px;
+    `,
+    body2: css`
+      font-size: 15px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 23px;
+    `,
+    body1: css`
+      font-size: 14px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 22px;
+    `,
+    caption: css`
+      font-size: 12px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 18px;
+    `,
+  },
+
+  colors: {
+    white: "#FFF",
+    black: "#000",
+    grey00: "#F6F8FA",
+    grey10: "#EAEEF2",
+    grey20: "#D0D7DE",
+    grey30: "#AFB8C1",
+    grey40: "#8C959F",
+    grey50: "#6E7781",
+    grey60: "#57606A",
+    grey70: "#434A53",
+    grey80: "#32383F",
+    grey90: "#24292F",
+
+    //변동 가능성 있음
+    primary01: "#DEDBFF",
+    primary02: "#B4ACFF",
+    primary03: "#7A6DF0",
+  },
+};
+
+export type ColorsTypes = typeof theme.colors;
+export type FontsTypes = typeof theme.fonts;


### PR DESCRIPTION
## 이슈 번호

<!-- 예: "closes #이슈번호" -->
#9 
## 작업한 내용
- theme관련 타입 및 Provier 초기 세팅
- color 및 font theme 세팅

## 작업 결과
![image](https://github.com/user-attachments/assets/4080d20f-4fe2-4ffc-9644-427bb9419920)

## 비고
찾아보니 styled-theming이라는걸 사용해서 다크모드/라이트모드를 조금 더 쉽게 관리할 수 있더라고! 사용하지 않아도 구현 가능해서 이부분은 추후 필요하면 조금 더 알아보고 적용해도 좋을 듯해서 일단 링크 남겨둘게~
https://styled-components.com/docs/tooling#styled-theming
