### PR TITLE
[Feat/#23] 리액트 쿼리가 에러를 감지하지 못하는 현상

### DIFF
--- a/src/chat/apis/createChatRoom.ts
+++ b/src/chat/apis/createChatRoom.ts
@@ -36,6 +36,6 @@ export const createChatRoom = () => {
     .then((res) => validate(res.data))
     .catch((error) => {
       console.error(error);
-      return undefined;
+      throw error;
     });
 };

--- a/src/chat/apis/getChatMessagesByRoomId.ts
+++ b/src/chat/apis/getChatMessagesByRoomId.ts
@@ -45,6 +45,6 @@ export const getChatMessagesByRoomId = (roomId: number) => {
     .then((res) => validate(res.data))
     .catch((error) => {
       console.error(error);
-      return undefined;
+      throw error;
     });
 };

--- a/src/chat/apis/sendChatMessage.ts
+++ b/src/chat/apis/sendChatMessage.ts
@@ -43,6 +43,6 @@ export const sendChatMessage = (request: SendChatMessageRequest) => {
     .then((res) => validate(res.data))
     .catch((error) => {
       console.error(error);
-      return undefined;
+      throw error;
     });
 };

--- a/src/tarot/apis/getTarotQuestionRecommends.ts
+++ b/src/tarot/apis/getTarotQuestionRecommends.ts
@@ -32,6 +32,6 @@ export const getTarotQuestionRecommends = async () => {
     .then((res) => validate(res.data))
     .catch((error) => {
       console.error(error);
-      return undefined;
+      throw error;
     });
 };

--- a/src/tarot/apis/getTarotReadingResultById.ts
+++ b/src/tarot/apis/getTarotReadingResultById.ts
@@ -51,6 +51,6 @@ export const getTarotReadingResultById = async (resultId: number) => {
     .then((res) => validate(res.data))
     .catch((error) => {
       console.error(error);
-      return undefined;
+      throw error;
     });
 };

--- a/src/tarot/apis/selectTarotCard.ts
+++ b/src/tarot/apis/selectTarotCard.ts
@@ -41,6 +41,6 @@ export const selectTarotCard = async (request: SelectTarotCardRequest) => {
     .then((res) => validate(res.data))
     .catch((error) => {
       console.error(error);
-      return undefined;
+      throw error;
     });
 };


### PR DESCRIPTION
## 이슈 번호

closes #23 

## 작업한 내용

- 현재 리액트 쿼리에서 에러를 캐치하지 못하는 문제가 있어 API 응답 실패 시 undefined 대신 rejected된 Promise를 반환하도록 개선했습니다.

## 작업 결과

.

## 비고

쿼리에서 반횐된 data의 타입 보장이 안되길래 왜그럴까 찾아보다가 발견..

다음 문서를 참고했습니다.
https://github.com/TanStack/query/discussions/4281
https://tkdodo.eu/blog/react-query-fa-qs#why-do-i-not-get-errors-